### PR TITLE
bugfix/FailWhenSwitchingtoOtherLayer

### DIFF
--- a/src/components/Canvas.vue
+++ b/src/components/Canvas.vue
@@ -354,6 +354,7 @@ export default defineComponent({
       const layer = layers.value[layerIndex.value];
       cursors.value = layer.points;
       currentColor.value = layer.color;
+      pointIndex.value = 0;
     };
     updateLayerIndex(0);
 


### PR DESCRIPTION
This may cause unexpected failure when changing the layer which has different total cursors and especially when the selected cursor number was larger than the total number of the target layer's cursors.